### PR TITLE
Add gradient declarations for Internet Explorer

### DIFF
--- a/public/stylesheets/sass/_linear-gradient.scss
+++ b/public/stylesheets/sass/_linear-gradient.scss
@@ -2,4 +2,6 @@
   background: $from;
   background: -moz-linear-gradient(top, $from, $to);
   background: -webkit-gradient(linear, left top, left bottom, color-stop(0, $from), color-stop(1, $to));
+  filter: progid:DXImageTransform.Microsoft.Gradient(GradientType=0, startColorstr='#{$from}', endColorstr='#{$to}');
+  -ms-filter: "progid:DXImageTransform.Microsoft.gradient(startColorstr='#{$from}', endColorstr='#{$to}')";
 }


### PR DESCRIPTION
Thanks for including some commonly used mixins. I've added some IE-specific declarations to _linear-gradient.scss for your consideration.
