### PR TITLE
Updated README.md to better specify how to install on a Rails 3.1 application

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,10 @@ After you've bundled, if you are using rails 3.1 or greater with asset pipelinin
 
     @import 'flutie';
 
-as a sass import in the application stylesheet manifest (app/assets/stylesheets/application.css).
+as a sass import in the application stylesheet manifest (app/assets/stylesheets/application.css.scss).
+
+If this is a new Rails 3.1 project you will need to rename the application.css manifest to application.css.scss so it is processed
+by the asset pipeline and sass to perform the @import.
 
 ### Rails 3
 


### PR DESCRIPTION
Hi, 

I've just updated the readme file with a simple change to better explain how to install Flutie in a Rails 3.1 application. Currently following the instructions will result in a 404 not found for 'assets/flutie' as the @import will not be processed by the asset pipeline in the manifest. The manifest file needs to be renamed application.css.scss for this to work and I've just included that in the documentation. I hope that's ok? 

Kind Regards

Tom
