### PR TITLE
Be More Clear on Rails Version for Rake Task

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ as a sass import in the application stylesheet manifest (app/assets/stylesheets/
 If this is a new Rails 3.1 project you will need to rename the application.css manifest to application.css.scss so it is processed
 by the asset pipeline and sass to perform the @import.
 
-### Rails 3
+### Rails 3.0
 
 After you've bundled, run the installer:
 


### PR DESCRIPTION
The rake is only needed on Rails 3.0. Yet the README said 'Rails 3' Rails 3 could be interpreted as Rails 3.0 and Rails 3.1. This commit fixes that. 
