### PR TITLE
Remove TimestampHelper

### DIFF
--- a/lib/flutie/timestamp_helper.rb
+++ b/lib/flutie/timestamp_helper.rb
@@ -1,9 +1,0 @@
-module TimestampHelper
-  def timestamp(time, options = {})
-    options = options.dup
-    tag = options.delete(:tag) { :time }
-    options[:title] = options[:title] == false ? nil : l(time)
-    options[:datetime] = time.to_s
-    content_tag(tag, "#{time_ago_in_words(time).capitalize} ago", options)
-  end
-end


### PR DESCRIPTION
- It was never documented as part of the public API.
- The same functionality exists in Rails core as `time_tag`.
  http://api.rubyonrails.org/classes/ActionView/Helpers/DateHelper.html#method-i-time_tag
