### PR TITLE
Add `bin/setup` file, modernize CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,38 +1,36 @@
-We love pull requests. Here's a quick guide:
+# Contributing
 
-1. Fork the repo.
+We love pull requests. Here's a quick guide.
 
-2. Run the tests. We only take pull requests with passing tests, and it's great
-to know that you have a clean slate: `bundle && rake`
+Fork the repo:
 
-3. Add a test for your change. Only refactoring and documentation changes
-require no new tests. If you are adding functionality or fixing a bug, we need
-a test!
+    git clone git@github.com:thoughtbot/flutie.git
 
-4. Make the test pass.
+Set up your machine:
 
-5. Push to your fork and submit a pull request.
+    ./bin/setup
 
+Make sure the tests pass:
 
-At this point you're waiting on us. We like to at least comment on, if not
-accept, pull requests within three business days (and, typically, one business
-day). We may suggest some changes or improvements or alternatives.
+    rake
 
-Some things that will increase the chance that your pull request is accepted,
-taken straight from the Ruby on Rails guide:
+Make your change. Add tests for your change. Make the tests pass:
 
-* Use Rails idioms and helpers
-* Include tests that fail without your code, and pass with it
-* Update the documentation, the surrounding one, examples elsewhere, guides,
-  whatever is affected by your contribution
+    rake
 
-Syntax:
+Push to your fork and [submit a pull request][pr].
 
-* Two spaces, no tabs.
-* No trailing whitespace. Blank lines should not have any space.
-* Prefer &&/|| over and/or.
-* MyClass.my_method(my_arg) not my_method( my_arg ) or my_method my_arg.
-* a = b and not a=b.
-* Follow the conventions you see used in the source already.
+[pr]: https://github.com/thoughtbot/flutie/compare/
 
-And in case we didn't emphasize it enough: we love tests!
+At this point you're waiting on us.
+We try to at least comment on within one business day.
+We may suggest some changes.
+
+Some things that will increase the chance that your pull request is accepted:
+
+* Write tests.
+* Follow our [style guide][style].
+* Write a [good commit message][commit].
+
+[style]: https://github.com/thoughtbot/guides/tree/master/style
+[commit]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

--- a/README.md
+++ b/README.md
@@ -8,11 +8,13 @@ There are helpers for setting a page title and for generating body classes.
 
 ## Installation & Upgrading
 
-Flutie is a Railtie and works with versions of Rails greater than 3.0.
+Flutie is a Railtie.
+We support the versions of Ruby and Rails
+listed in [.travis.yml](.travis.yml).
 
 It should be run as a gem and included in your `Gemfile`:
 
-    gem 'flutie'
+    gem "flutie"
 
 ## Helpers
 
@@ -70,4 +72,7 @@ The names and logos for thoughtbot are trademarks of thoughtbot, inc.
 
 ## License
 
-Flutie is Copyright © 2010, 2011, 2012, 2013, 2014 thoughtbot, inc.  It is free software, and may be redistributed under the terms specified in the LICENSE file.
+Flutie is Copyright © 2010-2015 thoughtbot, inc.
+It is free software,
+and may be redistributed under
+the terms specified in the [LICENSE](LICENSE) file.

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,14 @@
+#!/usr/bin/env sh
+
+# Run this script immediately after cloning the codebase.
+
+# Exit if any subcommand fails
+set -e
+
+# Set up Ruby dependencies via Bundler and Appraisal
+bundle install
+rake appraisal:install
+
+# Add binstubs to PATH in ~/.zshenv like this:
+#   export PATH=".git/safe/../../bin:$PATH"
+mkdir -p .git/safe


### PR DESCRIPTION
* Run `rake appraisal:install` in `bin/setup` to improve
  initial setup experience.
* Update Copyright to include 2015.
* Remove old style guidelines in `CONTRIBUTING.md`,
  instead referencing our style guide.
* Make supported Ruby and Rails versions more flexible and accurate
  by linking to the Travis matrix.