### PR TITLE
Pack less files in released gem

### DIFF
--- a/flutie.gemspec
+++ b/flutie.gemspec
@@ -13,9 +13,7 @@ Gem::Specification.new do |s|
   s.summary     = 'Flutie provides extra Rails view helpers'
   s.description = 'Flutie is a starting point for personal discovery'
 
-  s.files         = `git ls-files`.split("\n")
-  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
+  s.files         = `git ls-files -z`.split("\x0").reject { |f| f =~ %r(^(spec|gemfiles|bin)/) }
   s.require_paths = ['lib']
 
   s.add_development_dependency('appraisal', '~> 1.0')


### PR DESCRIPTION
This Pull Request packs less files into released gem.

Rationale: bundler/bundler#3207, 10KB => 9KB
- ignore `spec/*`, `gemfiles/*`, and `bin/`
- The executables is for development, don't need to pack into `.gem`
