### PR TITLE
Make page_title HTML-escape only once

### DIFF
--- a/lib/flutie/page_title_helper.rb
+++ b/lib/flutie/page_title_helper.rb
@@ -3,11 +3,13 @@ module PageTitleHelper
   def page_title(options = {})
     page_title = Flutie::PageTitle.new(options)
 
-    Flutie::PageTitlePresenter.new(
-      page_title.app_name,
-      content_for(page_title.page_title_symbol),
-      page_title.separator,
-      options[:reverse]
-    ).to_s
+    escape_once(
+      Flutie::PageTitlePresenter.new(
+        page_title.app_name,
+        content_for(page_title.page_title_symbol),
+        page_title.separator,
+        options[:reverse],
+      ).to_s,
+    )
   end
 end

--- a/lib/flutie/page_title_helper.rb
+++ b/lib/flutie/page_title_helper.rb
@@ -10,6 +10,6 @@ module PageTitleHelper
         page_title.separator,
         options[:reverse],
       ).to_s,
-    )
+    ).html_safe
   end
 end

--- a/spec/helpers/page_title_helper_spec.rb
+++ b/spec/helpers/page_title_helper_spec.rb
@@ -3,30 +3,57 @@ require 'rails_helper'
 describe PageTitleHelper, type: :helper do
   describe 'with no options' do
     subject { helper.page_title }
+
     it { should == 'Flutie' }
   end
+
   describe 'with a site name' do
     subject { helper.page_title(app_name: 'Test') }
+
     it { should == 'Test' }
   end
+
   describe 'with content for page title' do
     before { helper.content_for(:page_title, 'page title') }
     subject { helper.page_title }
+
     it { should == 'Flutie : page title' }
   end
+
   describe 'with content for page title, and an alternate separator' do
     before { helper.content_for(:page_title, 'page title') }
     subject { helper.page_title(separator: ' | ') }
+
     it { should == 'Flutie | page title' }
   end
+
   describe 'with an alternate symbol' do
     before { helper.content_for(:alt_page_title, 'page title') }
     subject { helper.page_title(page_title_symbol: :alt_page_title) }
+
     it { should == 'Flutie : page title' }
   end
+
   describe 'in a reversed position' do
     before { helper.content_for(:page_title, 'page title') }
     subject { helper.page_title(reverse: true) }
+
     it { should == 'page title : Flutie' }
+  end
+
+  it "html-escapes" do
+    helper.content_for(:page_title, 'Page & "Title"')
+
+    expect(
+      helper.page_title(app_name: "Flutie's", separator: " > "),
+    ).to eq("Flutie&#39;s &gt; Page &amp; &quot;Title&quot;")
+  end
+
+  it "html-escapes only once when rendering" do
+    helper.content_for(:page_title, 'Page & "Title"')
+
+    render(inline: '<%= page_title(app_name: "Flutie\'s", separator: " > ") %>')
+
+    expect(rendered).to eq("Flutie&#39;s &gt; Page &amp; &quot;Title&quot;")
   end
 end


### PR DESCRIPTION
This wraps the string returned by page_title with escape_once from
ActionView::Helpers::TagHelper to make sure it HTML-escapes only once.

Without it, rendering <%= page_title %> in an ERB template causes it
to be HTML-escaped twice.

https://api.rubyonrails.org/v6.1.0/classes/ActionView/Helpers/TagHelper.html#method-i-escape_once

Issue https://github.com/thoughtbot/flutie/issues/73